### PR TITLE
Use PyCryptodome instead PyCrypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycrypto>=2.6.1
+pycryptodomex>=3.4.3
 requests>=2.13.0
 colorama>=0.3.7
 tabulate>=0.7.7

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ]
     },
     install_requires = [
-        "pycrypto>=2.6.1",
+        "pycryptodomex>=3.4.3",
         "requests>=2.13.0",
         "colorama>=0.3.7",
         "tabulate>=0.7.7",

--- a/vaultcli/auth.py
+++ b/vaultcli/auth.py
@@ -10,7 +10,7 @@
 from vaultcli.workspacecypher import WorkspaceCypher
 from vaultcli.exceptions import ResourceUnavailable, Unauthorized, Forbidden
 
-from Crypto.Hash import SHA
+from Cryptodome.Hash import SHA
 from urllib.parse import urljoin
 
 import binascii

--- a/vaultcli/datacypher.py
+++ b/vaultcli/datacypher.py
@@ -9,8 +9,8 @@
 
 from vaultcli.pkcs7 import PKCS7Encoder
 
-from Crypto import Random
-from Crypto.Cipher import AES
+from Cryptodome import Random
+from Cryptodome.Cipher import AES
 
 import binascii
 import hashlib

--- a/vaultcli/workspacecypher.py
+++ b/vaultcli/workspacecypher.py
@@ -7,9 +7,9 @@
 #
 # Distributed under terms of the GNU GPLv3 license.
 
-from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_v1_5
-from Crypto.Signature import PKCS1_v1_5 as PKCS_sign
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Cipher import PKCS1_v1_5
+from Cryptodome.Signature import PKCS1_v1_5 as PKCS_sign
 
 import binascii
 


### PR DESCRIPTION
Seems that PyCrypto is now deprecated and not is packaged in Arch Linux. PyCryptodome is maintained and packaged.