### PR TITLE
Check server certificate, closes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ vaultcli config server https://your.vaultier.server.example.com
 vaultcli config key /location/of/your/vaultier.key
 ```
 
+Optionally, if your server have a self signed certificate, you can disable
+the certificate check.
+
+```bash
+vaultcli config verify false
+```
+
 ## Run
 
 Simply run `vaultcli` command with `-h` or `--help` to read the help of

--- a/contrib/_vaultcli
+++ b/contrib/_vaultcli
@@ -148,7 +148,7 @@ case ${words[1]} in
        '--type[show type (numeric)]' \
        '1:id:()'
     ;;
-  delete-card | delete-secret | delete-vault | delete-workspace \
+  delete-card | delete-secret | delete-vault | delete-workspace | \
     list-cards | list-secrets | list-vaults | tree-workspace)
     _arguments \
       '(-h --help)'{-h,--help}'[Show help]' \

--- a/contrib/_vaultcli
+++ b/contrib/_vaultcli
@@ -44,6 +44,7 @@ _vaultcli_add_secret_commands() {
 _arguments \
   '(-h --help)'{-h,--help}'[Show help]' \
   '(-c --config)'{-c,--config}'[Use custom configuration file]:configuration file:_files' \
+  '(-k --insecure)'{-k,--insecure}'[Allow SSL server connection without certs]' \
   '1: :_vaultcli_commands' \
   '*:: :->args'
 

--- a/vaultcli-sample.conf
+++ b/vaultcli-sample.conf
@@ -3,3 +3,18 @@ email = user@example.com
 server = https://example.com
 key = vaultier.key
 
+##
+# Option verify not is mandatory and is true by default, It checks that the
+# certificate of server is valid.
+#
+# The posible values for verify are:
+# * true  -> verify server certificate
+# * false -> not verify server certificate
+# * CA certificate path -> Use provided CA file to verify server certificate
+#
+# Samples:
+# verify = true
+# verify = false
+# verify = ~/ssl/my_ca.pem
+##
+verify = true

--- a/vaultcli/main.py
+++ b/vaultcli/main.py
@@ -107,8 +107,16 @@ def configure_client(args):
         err = 'vaultcli have a problem reading your keyfile.\n{0}'.format(e)
         raise SystemExit(err)
 
-    token = Auth(server, email, key).get_token()
-    return Client(server, token, key)
+    if args.insecure:
+        verify = False
+    else:
+        if config.get_default('verify') == None:
+            verify = True
+        else:
+            verify = False if config.get_default('verify').lower() == 'false' else config.get_default('verify')
+
+    token = Auth(server, email, key, verify).get_token()
+    return Client(server, token, key, verify)
 
 def import_workspace(args):
     try:
@@ -582,6 +590,7 @@ def main():
     """Create an arparse and subparse to manage commands"""
     parser = argparse.ArgumentParser(description='Manage your Vaultier secrets from cli.')
     parser.add_argument('-c', '--config', metavar='file', help='custom configuration file')
+    parser.add_argument('-k', '--insecure', action='store_true', help='allow SSL server connection without certs')
     subparsers = parser.add_subparsers(metavar='', dest='command')
     subparsers.required = True
 


### PR DESCRIPTION
By default requires a valid server certificate. The user can pass -k or
--insecure option to avoid this behavior.

Also, the certificate check can be set in config file.