### PR TITLE
Fix small issue in raise

### DIFF
--- a/vaultcli/workspacecypher.py
+++ b/vaultcli/workspacecypher.py
@@ -53,7 +53,7 @@ class WorkspaceCypher(object):
         try:
             decrypted = self.priv.decrypt(raw_cipher_data,'')
         except ValueError as ex:
-            if ex.message == "Message too large":
-                raise Exception("Parece que no estas usando la clave privada adecuada")
-            raise ex
+            if str(ex) == 'Message too large':
+                raise Exception('Seems that you\'re not using the proper private key')
+            raise
         return decrypted


### PR DESCRIPTION
In Python 3 an exception has not message attribute. We must use str()
instead.